### PR TITLE
Update manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,7 +5,8 @@
         {
             "src": "/images/logo.png",
             "type": "image/png",
-            "sizes": "1024x1024"
+            "sizes": "1024x1024",
+            "purpose": "any maskable"
         }
     ],
     "start_url": ".",


### PR DESCRIPTION
Fixes Lighthouse warning that Manifest didn't have a maskable icon

credit YouTube comment by Bruno Pais